### PR TITLE
Fix for double quotes within double quotes

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,9 +14,9 @@
     <div class="main">
         <div class="topnav">
             <a class="active" href="#home">Home</a>
-            <a href="#news">Pinoy Creators</a>
-            <a href="#contact">PH Demonlist</a>
-            <a href="#about">About</a>
+            <a href="html/creators.html">Pinoy Creators</a>
+            <a href="html/demonlist.html">PH Demonlist</a>
+            <a href="html/about.html">About</a>
         </div>
         <div class="row">
             <div class="col-md-12">

--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
 		<hr />
 	
 	<!-- JS Scripts -->
+	
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
 	
     <script src="index.js"></script>

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ add_btn.onclick = function(){
 					  var poll_leveldata = document.createElement("input");
 					  poll_leveldata.setAttribute("id", "poll_votedata");
 					  poll_leveldata.setAttribute("type", "hidden");
-					  poll_leveldata.setAttribute("value", JSON.stringify(obj));
+					  poll_leveldata.setAttribute("value", JSON.stringify(obj).replace(/\"/g, "&quot;")); //replace all instances of " with &quot;, so that the HTML code doesn't get messed up
 
 					  var poll_submit = document.createElement("button");
 					  poll_submit.innerHTML = "Send Vote";
@@ -128,7 +128,7 @@ function clearAllEntries(){
 
 function submitVote() {
 	var choice_string = document.getElementById("poll_votedata").value; //the entirety of the fetched obj, but stringified
-	var choice_json = JSON.parse(choice_string);
+	var choice_json = JSON.parse(choice_string.replace(/&quot;/g, "\"")); //replace all &quot with ", so that the string can be parsed
 	
 	//console.log("obj string: " + choice_string);
 	


### PR DESCRIPTION
Technically, the webpage works as intended with setting double quotes inside the input value. The double quotes only really break when modifying the hidden input value externally, such as when tampering with the code via Inspect Element.

This "fix" actually just makes the webpage easier to break with Inspect Element, but the webpage has always been vulnerable, so in our case, it makes it easier to see how it breaks.